### PR TITLE
Add Home Assistant nodes and projects (git repo for flows) support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,7 @@ FROM nodered/node-red-docker
 # For credentials that look like paths, set file contents as credential.
 COPY 10-mqtt.js /usr/src/node-red/node_modules/node-red/nodes/core/io/10-mqtt.js
 COPY data/ /data
+COPY settings.js /usr/src/node-red/settings.js
+# Make this a symlink so that I can update settings on volume mounted /data. 
+RUN ln -s /usr/src/node-red/settings.js /data/settings.js
 VOLUME /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM nodered/node-red-docker
-RUN npm i node-red-dashboard
+FROM nodered/node-red-docker:0.18.7-v8
+RUN npm i node-red-dashboard node-red-contrib-contextbrowser Spartan-II-117/node-red-contrib-home-assistant
 RUN ln -s /usr/src/node-red/settings.js /data/settings.js
 
 # For credentials that look like paths, set file contents as credential.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM nodered/node-red-docker
+RUN npm i node-red-dashboard
+RUN ln -s /usr/src/node-red/settings.js /data/settings.js
 
 # For credentials that look like paths, set file contents as credential.
 COPY 10-mqtt.js /usr/src/node-red/node_modules/node-red/nodes/core/io/10-mqtt.js
 COPY data/ /data
 COPY settings.js /usr/src/node-red/settings.js
+
 # Make this a symlink so that I can update settings on volume mounted /data. 
-RUN ln -s /usr/src/node-red/settings.js /data/settings.js
 VOLUME /data

--- a/settings.js
+++ b/settings.js
@@ -235,5 +235,13 @@ module.exports = {
             // Whether or not to include audit events in the log output
             audit: false
         }
-    }
+    },
+
+    
+    // Enable projects: https://nodered.org/docs/user-guide/projects/
+    editorTheme: {
+       projects: {
+           enabled: true
+       }
+   }
 }

--- a/settings.js
+++ b/settings.js
@@ -72,9 +72,7 @@ module.exports = {
     // Note: once you set this property, do not change it - doing so will prevent
     // node-red from being able to decrypt your existing credentials and they will be
     // lost.
-    // TODO: Create this secret in the installer. Just use Vault's random generator. 
-    //       Will also nee to add secret to docker-compose
-    //credentialSecret: fs.readFileSync('/run/secrets/cred_secret').trim(), //  c"a-secret-key",
+    credentialSecret: fs.readFileSync('/run/secrets/cred_secret'), //  c"a-secret-key",
 
     // By default, all user data is stored in the Node-RED install directory. To
     // use a different location, the following property can be used

--- a/settings.js
+++ b/settings.js
@@ -72,7 +72,10 @@ module.exports = {
     // Note: once you set this property, do not change it - doing so will prevent
     // node-red from being able to decrypt your existing credentials and they will be
     // lost.
-    credentialSecret: fs.readFileSync('/run/secrets/cred_secret'), //  c"a-secret-key",
+
+    // I tried to use this. It caused the application to crash. I'd rather encrypt credentials, 
+    // but I figure that as long as I'm only storing paths to the actual credentials, I'm not that worried about encrypting it. 
+    //credentialSecret: fs.readFileSync('/run/secrets/cred_secret'), //  c"a-secret-key",
 
     // By default, all user data is stored in the Node-RED install directory. To
     // use a different location, the following property can be used
@@ -241,5 +244,15 @@ module.exports = {
        projects: {
            enabled: true
        }
+   },
+
+   // Store the context.
+    contextStorage: {
+        default: {
+            module: "localfilesystem",
+            config:{                  // config
+                dir:"/data/context"
+            }
+        }
    }
 }


### PR DESCRIPTION
Projects (https://nodered.org/docs/user-guide/projects/) are basically git repos for Node-RED flows. This adds support for them. 

It also adds the libraries so that Node-RED can work on Home Assistant nodes. 